### PR TITLE
 Break up the last BRACES lesson to avoid error/exit

### DIFF
--- a/p.typ
+++ b/p.typ
@@ -334,8 +334,13 @@ S:/* Hello world in C, K&R style */
  :    return 0;
  :}
  :
+ :<?php
+ :  // Hello world in PHP
+ :  echo 'Hello World!';
+ :?>
  :
- ://Hello world in C#
+I:(6) Try some more coding
+S://Hello world in C#
  :class HelloWorld
  :{
  :    static void Main()
@@ -344,11 +349,6 @@ S:/* Hello world in C, K&R style */
  :    }
  :}
  :
- :
- :<?php
- :  // Hello world in PHP
- :  echo 'Hello World!';
- :?>
  :
  :
  :// Hello world in Delphi

--- a/p.typ
+++ b/p.typ
@@ -349,8 +349,6 @@ S://Hello world in C#
  :    }
  :}
  :
- :
- :
  :// Hello world in Delphi
  :Program Hello_World;
  :


### PR DESCRIPTION
The tutor exited and displayed this error on reaching the lesson:

gtypist: line 362: data exceeds screen length: