### PR TITLE
fixed issue #6.

### DIFF
--- a/p.typ
+++ b/p.typ
@@ -343,24 +343,8 @@ S:/* Hello world in C, K&R style */
  :        System.Console.WriteLine("Hello, World!");
  :    }
  :}
- :
- :
- :<?php
- :  // Hello world in PHP
- :  echo 'Hello World!';
- :?>
- :
- :
- :// Hello world in Delphi
- :Program Hello_World;
- :
- :{$APPTYPE CONSOLE}
- :
- :Begin
- :  WriteLn('Hello World');
- :End.
 
-Q:Do you want to continue to lesson P7 [Y/N] ? 
+Q:Do you want to continue to lesson P6 [Y/N] ? 
 N:MENU
 
 


### PR DESCRIPTION
Fixed the following error: "gtypist: line 363: data exceeds screen length:" which is also mentioned in issue #6.
The problem is that the last exercise in lesson 5 is longer than the common 80x24 terminal size. I fixed the error by deleting a few lines to fit within 24 lines.

Also fixed a typo. After lesson 5 comes lesson 6.