### PR TITLE
Removed trailing spaces

### DIFF
--- a/p.typ
+++ b/p.typ
@@ -37,8 +37,8 @@ M: "The P series contains the following 11 lessons"
 # Lesson P1—Special Characters Review
 *:SPECIAL_NUMS_REVIEW
 B:Lesson P1
-T:In the P series of lessons we work on special characters with an 
- :emphasis on characters that are used when writing code in programming 
+T:In the P series of lessons we work on special characters with an
+ :emphasis on characters that are used when writing code in programming
  :or markup languages.
  :
  :We will start by reviewing the special characters that share keys with
@@ -60,11 +60,11 @@ D:&&&& **** (((( )))) &*() )(*&
  :(()) &&** *&*& (&&) (**) (())
 
 I:(4) Practice with these characters
-D:)!(@ #*$& %^%^ @@)) $$&& *$*$ 
- :(@@) ##)( %^%^ !#*& )!)! @*@* 
+D:)!(@ #*$& %^%^ @@)) $$&& *$*$
+ :(@@) ##)( %^%^ !#*& )!)! @*@*
 
 I:(5) Try some sentences
-S:It is hard to believe, but 230 minus 220 times one half equals 5! 
+S:It is hard to believe, but 230 minus 220 times one half equals 5!
  :(And 5!, of course, equals 5 * 4 * 3 * 2 * 1.)
  :
  :username@domainname.com is the #1 most common format for email addresses.
@@ -84,11 +84,11 @@ S:# Hello world in Python 2
  :
  :# Hello world in Python 3
  :print("Hello world!")
- : 
+ :
  :
  :# Hello world in Ruby
  :puts "Hello World!"
- : 
+ :
  :
  :;;; Hello world in Emacs Lisp
  :(defun hello-world()
@@ -107,7 +107,7 @@ S:# Hello world in Python 2
  :
  :% Hello world in MATLAB
  :disp('Hello World!');
-Q:Do you want to continue to lesson P2 [Y/N] ? 
+Q:Do you want to continue to lesson P2 [Y/N] ?
 N:MENU
 
 
@@ -156,7 +156,7 @@ S:// Hello world in JavaScript
  :say 'Hello World!';
  :
  :
- :// Hello world in TypeScript 
+ :// Hello world in TypeScript
  :alert('Hello World!');
  :
  :
@@ -171,7 +171,7 @@ S:// Hello world in JavaScript
  :
  :End Class
 
-Q:Do you want to continue to lesson P3 [Y/N] ? 
+Q:Do you want to continue to lesson P3 [Y/N] ?
 N:MENU
 
 
@@ -204,11 +204,11 @@ D:'__' +/-= "--" ::++ ?__?
 I:(6) Try some sentences
 S:The hyphen ("-") is used for compound words; the en dash,
  :which is longer than a hyphen, is used to indicate a range.
- :If you cannot use a true en dash, some people accept two 
+ :If you cannot use a true en dash, some people accept two
  :hyphens ("--") instead.  The em dash is even longer than an
  :en dash, and is used to indicate a break in a sentence.  If
- :you cannot use a true em dash, some people accept three 
- :hyphens ("---") instead. 
+ :you cannot use a true em dash, some people accept three
+ :hyphens ("---") instead.
  :
  :If you cannot emphasise text by setting it in italic or by
  :underlining it, you can show emphasis with underscores ("like
@@ -227,12 +227,12 @@ S:int first_number = 7;
  :
  :let a = 'string';
  :let b = 'string';
- :if (a === b) console.log('"a" and "b" are equal'); 
+ :if (a === b) console.log('"a" and "b" are equal');
  :
  :
  :if ((10 / 10) === 5 % 4) console.log('Yep, that is how math works');
 
-Q:Do you want to continue to lesson P4 [Y/N] ? 
+Q:Do you want to continue to lesson P4 [Y/N] ?
 N:MENU
 
 
@@ -244,7 +244,7 @@ D:Glib jocks quiz nymph to vex dwarf.
  :Sphinx of black quartz, judge my vow!
  :Two driven jocks help fax my big quiz.
 
-I:(2) Hit the < key with your k finger 
+I:(2) Hit the < key with your k finger
 D:kkkk <<<< kk<< ,,<< ,k<K K,,K <kk<
  :kkKK <<,, ,<<, k<<k <KK< ,k<K ,<k<
 
@@ -293,12 +293,12 @@ S:<!DOCTYPE html>
  :
  :</body>
  :</html>
-Q:Do you want to continue to lesson P5 [Y/N] ? 
+Q:Do you want to continue to lesson P5 [Y/N] ?
 N:MENU
 
 
 # Lesson P5—Curly Braces
-*:BRACES 
+*:BRACES
 B:Lesson P5
 I:(1) Warm up
 D:Five quacking zephyrs jolt my wax bed.
@@ -317,7 +317,7 @@ I:(4) Practice these characters together
 D:{{}} }}{{ ;;;; {{{{ }}}} }};;
  :{{:: "{}" {00} {ll} }}{{ :{}:
 
-I:(5) Try some coding 
+I:(5) Try some coding
 S:/* Hello world in C, K&R style */
  :main()
  :{
@@ -325,7 +325,7 @@ S:/* Hello world in C, K&R style */
  :  return 0;
  :}
  :
- :// Hello world in C++ 
+ :// Hello world in C++
  :#include <iostream.h>
  :
  :main()
@@ -360,7 +360,7 @@ S:/* Hello world in C, K&R style */
  :  WriteLn('Hello World');
  :End.
 
-Q:Do you want to continue to lesson P7 [Y/N] ? 
+Q:Do you want to continue to lesson P7 [Y/N] ?
 N:MENU
 
 
@@ -368,7 +368,7 @@ N:MENU
 *:SQUARE_BRACKETS
 B:Lesson P6
 
-I:(1) Review 
+I:(1) Review
 D:;;;; ;';' ;p;p ;-;- ;";" ;/;/ ;?;? ;:;: ;_;_
  :;;PP ;p-/ :;:; ;;;; _P?p "PP" p-p; P/P? --??
 I:(2) Use your ;-finger for the [-key
@@ -379,7 +379,7 @@ I:(3) Use your ;-finger for the ]-key
 D:;;;; ]]]] ;];] ;;]] ]];; ];];
  :]]]] ];]; ]']' ]p]p ]-]- ]/]/
  :]]]] ]:]: ]"]" ]P]P ]_]_ ]?]?
-I:(4) Practice the ] and [ keys 
+I:(4) Practice the ] and [ keys
 D:;[]; ];[; ;;][ ];;[ [];; ][;;
  :[;'] [p-] [-/] [:"] [P_] [_?]
 I:(5) Try some sentences
@@ -390,7 +390,7 @@ S:Hello [name]!  How are you this [time_of_day]?
  :And how about [spouse]? [Is he/Is she/Are they] doing well?
  :
  :How about those [local_sports_team], eh?
-I:(6) The [- and ]-keys are frequently used when working with arrays 
+I:(6) The [- and ]-keys are frequently used when working with arrays
 S:int array[10];
  :int array_one[];
  :double array_two[];
@@ -406,7 +406,7 @@ S:int array[10];
  :];
 
 
-Q:Do you want to continue to lesson P7 [Y/N] ? 
+Q:Do you want to continue to lesson P7 [Y/N] ?
 N:MENU
 
 
@@ -430,8 +430,8 @@ D:~~`` `~~` `!!` ``QQ zz`` ~~11
  :``~~ ~``~ ~!!~ ~~ZZ qq~~ ``11
  :`~~` `ZZ` QQ~~ aa~~ `11` ~!!~
 
-I:(5) Try some terminal commands 
-S:cd ~/Documents 
+I:(5) Try some terminal commands
+S:cd ~/Documents
  :cp ~/Documents/resume.txt ~/Documents/resume.txt.bk
  :mv ~/Documents/resume.md ~/Documents/resume.html
  :rm ~/Documents/resume.md
@@ -440,7 +440,7 @@ I:(6) Try some programing with template literals
 S:let greeting = 'Hello';
  :console.log(`${greeting}, world`);
  :
- :`${variable}` 
+ :`${variable}`
  :
  :`Hello, ${name}, how are you?`
  :
@@ -452,20 +452,20 @@ S:let greeting = 'Hello';
  :console.log(`Fifteen is ${a + b} and
  :not ${2 * (a + b)}`);
  :
- :const classes = `header ${ isLargeScreen() ? '' : 
+ :const classes = `header ${ isLargeScreen() ? '' :
  :  `icon-${item.isCollapsed ? 'expander' : 'collapser'}` }`;
  :
- :sudo chown `id -u` /somedir 
+ :sudo chown `id -u` /somedir
 
 
-Q:Do you want to continue to lesson P8 [Y/N] ? 
+Q:Do you want to continue to lesson P8 [Y/N] ?
 N:MENU
 
 
 # Lesson P8—Pipe
 *:PIPE
 B:Lesson P8
-I:(1) Review 
+I:(1) Review
 D:2030 5946 1411 4062 8077 8786 2534 9640
  :@)#) %($^ !$!! $)^@ *)&& *&*^ @%#$ (^$)
  :
@@ -520,7 +520,7 @@ S:// match a valid phone number
  :// match an HTML tag
  :/^<([A-Za-z]+)([^<]+)*(?:>(.*)<\/\1>|\s+\/>)$/
 
-Q:Do you want to continue to lesson P9 [Y/N] ? 
+Q:Do you want to continue to lesson P9 [Y/N] ?
 N:MENU
 
 
@@ -528,10 +528,10 @@ N:MENU
 *:PRACTICE_1
 B:Lesson P9
 I:(1) Practice with simple programs.  Try a palindrome finder in Python
-S:# function to check string is 
- :# palindrome or not 
+S:# function to check string is
+ :# palindrome or not
  :def isPalindrome(str):
- :    for i in xrange(0, len(str)/2): 
+ :    for i in xrange(0, len(str)/2):
  :        if str[i] != str[len(str)-i-1]:
  :            return False
  :    return True
@@ -545,7 +545,7 @@ S:// function to check if a string is a palindrome
  :  return true;
  :}
 
-I:(3) Try the same problem in C++ 
+I:(3) Try the same problem in C++
 S:bool IsPalindrome(const char* psz)
  :{
  :    int i = 0;
@@ -572,28 +572,28 @@ S:bool IsPalindrome(const char* psz)
 
 I:(4) Try the same problem in C, using functions and pointers (part 1)
 S:#include <stdio.h>
- : 
+ :
  :int is_palindrome(char*);
  :void copy_string(char*, char*);
  :void reverse_string(char*);
  :int string_length(char*);
  :int compare_string(char*, char*);
- : 
+ :
  :int main()
  :{
  :   char string[100];
  :   int result;
- : 
+ :
  :   printf("Input a string\n");
  :   gets(string);
- : 
+ :
  :   result = is_palindrome(string);
- : 
+ :
  :   if ( result == 1 )
  :      printf("\"%s\" is a palindrome string.\n", string);
  :   else
- :      printf("\"%s\" isn't a palindrome string.\n", string); 
- : 
+ :      printf("\"%s\" isn't a palindrome string.\n", string);
+ :
  :   return 0;
  :}
 
@@ -602,17 +602,17 @@ S:int is_palindrome(char *string)
  :{
  :   int check, length;
  :   char *reverse;
- : 
- :   length = string_length(string);    
- :   reverse = (char*)malloc(length+1);    
- : 
+ :
+ :   length = string_length(string);
+ :   reverse = (char*)malloc(length+1);
+ :
  :   copy_string(reverse, string);
  :   reverse_string(reverse);
- : 
+ :
  :   check = compare_string(string, reverse);
- : 
+ :
  :   free(reverse);
- : 
+ :
  :   if ( check == 0 )
  :      return 1;
  :   else
@@ -622,17 +622,17 @@ S:int is_palindrome(char *string)
 I:(6) Try the same problem in C, continued
 S:int string_length(char *string)
  :{
- :   int length = 0;  
- : 
+ :   int length = 0;
+ :
  :   while(*string)
  :   {
  :      length++;
  :      string++;
  :   }
- : 
+ :
  :   return length;
  :}
- : 
+ :
  :void copy_string(char *target, char *source)
  :{
  :   while(*source)
@@ -645,37 +645,37 @@ S:int string_length(char *string)
  :}
 
 I:(7) Try the same problem in C, continued
-S:void reverse_string(char *string) 
+S:void reverse_string(char *string)
  :{
  :   int length, c;
  :   char *begin, *end, temp;
- : 
+ :
  :   length = string_length(string);
- : 
+ :
  :   begin = string;
  :   end = string;
- : 
+ :
  :   for ( c = 0 ; c < ( length - 1 ) ; c++ )
  :       end++;
- : 
- :   for ( c = 0 ; c < length/2 ; c++ ) 
- :   {        
+ :
+ :   for ( c = 0 ; c < length/2 ; c++ )
+ :   {
  :      temp = *end;
  :      *end = *begin;
  :      *begin = temp;
- : 
+ :
  :      begin++;
  :      end--;
  :   }
  :}
- : 
+ :
  :int compare_string(char *first, char *second)
  :{
  :   while(*first==*second)
  :   {
  :      if ( *first == '\0' || *second == '\0' )
  :         break;
- : 
+ :
  :      first++;
  :      second++;
  :   }
@@ -685,7 +685,7 @@ S:void reverse_string(char *string)
  :      return -1;
  :}
 
-Q:Do you want to continue to lesson P10 [Y/N] ? 
+Q:Do you want to continue to lesson P10 [Y/N] ?
 N:MENU
 
 
@@ -810,7 +810,7 @@ S:        else if (HAVE_MORECORE) {
  :  return (released != 0) ? 1 : 0;
  :}
 
-Q:Do you want to continue to lesson P11 [Y/N] ? 
+Q:Do you want to continue to lesson P11 [Y/N] ?
 N:MENU
 
 
@@ -1021,7 +1021,7 @@ S:function codeGenerator(node) {
  :    case 'ExpressionStatement':
  :      return (
  :        codeGenerator(node.expression) +
- :        ';' 
+ :        ';'
  :      );
  :    case 'CallExpression':
  :      return (


### PR DESCRIPTION
While creating a single-space version for myself (and to contribute to https://github.com/inaimathi/gtypist-single-space) I noticed a lot of trailing spaces.

I don't know that any of them are actually causing problems, but it seemed best to clean them up.