### PR TITLE
emphasise -> emphasize

### DIFF
--- a/p.typ
+++ b/p.typ
@@ -210,7 +210,7 @@ S:The hyphen ("-") is used for compound words; the en dash,
  :you cannot use a true em dash, some people accept three 
  :hyphens ("---") instead. 
  :
- :If you cannot emphasise text by setting it in italic or by
+ :If you cannot emphasize text by setting it in italic or by
  :underlining it, you can show emphasis with underscores ("like
  :_this_").
 


### PR DESCRIPTION
This might mostly be personal preference - but from some quick research, emphasize _appears_ to be the more common spelling.

[Source](https://writingexplained.org/emphasise-or-emphasize-difference#:~:text=Is%20it%20emphasise%20or%20emphasize,both%20British%20and%20American%20English.)
> today, emphasize is more common in both British and American English